### PR TITLE
Added ED slab support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ run
 *.jks
 
 libs
+classes

--- a/src/main/java/cjminecraft/doubleslabs/addons/engineersdecor/EngineersDecorSlabSupport.java
+++ b/src/main/java/cjminecraft/doubleslabs/addons/engineersdecor/EngineersDecorSlabSupport.java
@@ -1,0 +1,57 @@
+package cjminecraft.doubleslabs.addons.engineersdecor;
+
+import cjminecraft.doubleslabs.api.ISlabSupport;
+import net.minecraft.block.BlockSlab;
+import net.minecraft.block.properties.PropertyInteger;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class EngineersDecorSlabSupport implements ISlabSupport {
+    private final Class<?> slab;
+    private final PropertyInteger parts;
+
+    public EngineersDecorSlabSupport() {
+        Class<?> slab = null;
+        PropertyInteger parts = null;
+        try {
+            slab = Class.forName("wile.engineersdecor.blocks.BlockDecorSlab");
+            parts = (PropertyInteger)slab.getField("PARTS").get(null);
+        } catch(ClassNotFoundException|NoSuchFieldException|IllegalAccessException ignored) {
+            slab = null;
+            parts = null;
+        }
+        this.slab = slab;
+        this.parts = parts;
+    }
+
+    @Override
+    public boolean isValid(World world, BlockPos pos, IBlockState state) {
+        return (slab != null) && (state.getBlock().getClass().equals(slab)) && (state.getValue(parts) < 2);
+    }
+
+    @Override
+    public boolean isValid(ItemStack stack, EntityPlayer player, EnumHand hand) {
+        return (slab != null) && (stack.getItem() instanceof ItemBlock) && (((ItemBlock)stack.getItem()).getBlock().getClass().equals(slab));
+    }
+
+    @Override
+    public BlockSlab.EnumBlockHalf getHalf(World world, BlockPos pos, IBlockState state) {
+        return ((slab != null) && (state.getValue(parts) == 0)) ? BlockSlab.EnumBlockHalf.BOTTOM : BlockSlab.EnumBlockHalf.TOP;
+    }
+
+    @Override
+    public IBlockState getStateForHalf(World world, BlockPos pos, ItemStack stack, BlockSlab.EnumBlockHalf half) {
+        final IBlockState state = ((ItemBlock)stack.getItem()).getBlock().getDefaultState();
+        return (slab == null) ? (state) : (state.withProperty(parts, half == BlockSlab.EnumBlockHalf.BOTTOM ? 0 : 1));
+    }
+
+    @Override
+    public boolean areSame(World world, BlockPos pos, IBlockState state, ItemStack stack) {
+        return ((ItemBlock)stack.getItem()).getBlock() == state.getBlock();
+    }
+}

--- a/src/main/java/cjminecraft/doubleslabs/api/SlabSupport.java
+++ b/src/main/java/cjminecraft/doubleslabs/api/SlabSupport.java
@@ -6,6 +6,7 @@ import cjminecraft.doubleslabs.addons.erebus.ErebusSlabSupport;
 import cjminecraft.doubleslabs.addons.libraryex.LibraryExSlabSupport;
 import cjminecraft.doubleslabs.addons.minecraft.MinecraftSlabSupport;
 import cjminecraft.doubleslabs.addons.thebetweenlands.TheBetweenlandsSlabSupport;
+import cjminecraft.doubleslabs.addons.engineersdecor.EngineersDecorSlabSupport;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
@@ -39,6 +40,9 @@ public class SlabSupport {
 
         if (Loader.isModLoaded("thebetweenlands"))
             addSlabSupport(new TheBetweenlandsSlabSupport());
+
+        if (Loader.isModLoaded("engineersdecor"))
+            addSlabSupport(new EngineersDecorSlabSupport());
     }
 
     public static void addSlabSupport(@Nonnull ISlabSupport support) {


### PR DESCRIPTION
From the issue https://github.com/stfwi/engineers-decor/issues/94 posted in the Engineer's Decor repo here a PR for slab supports. Unfortunately I cannot directly inherit from `SlabBlock` as my slabs have additional properties and go along with another "slab slice" class. 
The approach is based on reflection (only initialisation), so you would not have a hard compile time dependency. 
Briefly tested on a dev machine in single player (creative, `engineersdecor-1.12.2-1.0.20-b3`), should be double checked with dedicated server / client only when merging.
1.14 and 1.15 ED versions have the same properties and class paths.

![2020-04-14_22 59 42](https://user-images.githubusercontent.com/28822525/79275540-ad933c80-7ea6-11ea-8d51-d420041a714a.png)
