### PR TITLE
Reformat JSON to fix bug

### DIFF
--- a/update.json
+++ b/update.json
@@ -35,8 +35,8 @@
     "0.9.1": "=Fixed a client crash",
     "0.9.2": "+Added Tile Entity rendering to slabs",
     "0.10.0": "+Added a blacklist to disable slabs from being placed vertically\n=Improved the slab blacklist\n=Fix the back of vertical slab rotations\n=Improved ambient occlusion",
-    "0.11.0": "+Completely rewritten the entire mod fixing various issues in the process\n+Added vertical slab items which can be crafted from regular slabs\n+Added player specific placement options\n+Added a keybinding to toggle vertical slab placement from regular slabs\n+Added a crafting blacklist to disable the crafting recipe of slabs to vertical slabs\n=Tweaked slab rendering to use the double slab model when both slabs are of the same type\n=Fixed ambient occlusion for slabs (without OptiFine and shaders)\n=Improved dynamic placement mechanism\n=Fixed numerous crashes\n=Improved culling mechanism to work better with transparent and non full models\n+Added support for extended blockstates meaning mods like BlockCraftery finally work\n=Improved container support to work in it's entirety"
-	"0.11.1": "=Fixed some crashes"
+    "0.11.0": "+Completely rewritten the entire mod fixing various issues in the process\n+Added vertical slab items which can be crafted from regular slabs\n+Added player specific placement options\n+Added a keybinding to toggle vertical slab placement from regular slabs\n+Added a crafting blacklist to disable the crafting recipe of slabs to vertical slabs\n=Tweaked slab rendering to use the double slab model when both slabs are of the same type\n=Fixed ambient occlusion for slabs (without OptiFine and shaders)\n=Improved dynamic placement mechanism\n=Fixed numerous crashes\n=Improved culling mechanism to work better with transparent and non full models\n+Added support for extended blockstates meaning mods like BlockCraftery finally work\n=Improved container support to work in it's entirety",
+    "0.11.1": "=Fixed some crashes",
   },
   "1.14.4": {
     "1.0.0": "Initial port to 1.14",


### PR DESCRIPTION
Appended commas to the end of line 38 and 39 to properly complete the JSON. The lack of commas caused a malformed JSON exception in GSON. See below stack trace.

com.google.gson.JsonSyntaxException: com.google.gson.stream.MalformedJsonException: Unterminated object at line 39 column 3 path $..0.11.0
        at com.google.gson.Gson.fromJson(Gson.java:902) ~[server-1.15.2-extra.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:852) ~[server-1.15.2-extra.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:801) ~[server-1.15.2-extra.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:773) ~[server-1.15.2-extra.jar:?]
        at net.minecraftforge.fml.VersionChecker$1.process(VersionChecker.java:214) ~[?:?]
        at java.lang.Iterable.forEach(Iterable.java:75) [?:1.8.0_275]
        at net.minecraftforge.fml.VersionChecker$1.run(VersionChecker.java:157) [?:?]
Caused by: com.google.gson.stream.MalformedJsonException: Unterminated object at line 39 column 3 path $..0.11.0
        at com.google.gson.stream.JsonReader.syntaxError(JsonReader.java:1559) ~[server-1.15.2-extra.jar:?]
        at com.google.gson.stream.JsonReader.doPeek(JsonReader.java:491) ~[server-1.15.2-extra.jar:?]
        at com.google.gson.stream.JsonReader.hasNext(JsonReader.java:414) ~[server-1.15.2-extra.jar:?]
        at com.google.gson.internal.bind.ObjectTypeAdapter.read(ObjectTypeAdapter.java:69) ~[server-1.15.2-extra.jar:?]
        at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:41) ~[server-1.15.2-extra.jar:?]
        at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:187) ~[server-1.15.2-extra.jar:?]
        at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:145) ~[server-1.15.2-extra.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:887) ~[server-1.15.2-extra.jar:?]
        ... 6 more