### PR TITLE
(1.21.1) Fix bug with mixed slabs and waterlogging

### DIFF
--- a/common/src/main/java/cjminecraft/doubleslabs/common/hooks/MixedDoubleSlabBlockHooks.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/common/hooks/MixedDoubleSlabBlockHooks.java
@@ -18,6 +18,7 @@ import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.BlockHitResult;
@@ -139,7 +140,8 @@ public class MixedDoubleSlabBlockHooks extends DynamicSlabBlockHooks {
                     return;
                 }
 
-                final var slabState = slabContainer.getBlockState();
+                var slabState = slabContainer.getBlockState();
+				slabState = slabState.setValue(BlockStateProperties.WATERLOGGED, false);
 
                 level.setBlock(pos, slabState, level.isClientSide() ? 11 : 3);
 


### PR DESCRIPTION
When you placed a different slab type onto a waterlogged slab to create a double slab, then broke the slab that hadn't been waterlogged, the remaining slab would return to a waterlogged state (but not flow out until updated).

This fixes it so the water is removed, like what happens with two slabs of the same type (and vertical slabs, which never had this issue).