### PR TITLE
(1.21.1) Fix crash when placing vertical slab into water

### DIFF
--- a/common/src/main/java/cjminecraft/doubleslabs/library/helpers/VerticalSlabModelHelper.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/library/helpers/VerticalSlabModelHelper.java
@@ -5,6 +5,7 @@ import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 
 import java.util.Map;
 
@@ -20,7 +21,8 @@ public class VerticalSlabModelHelper implements IVerticalSlabModelHelper {
 
     @Override
     public BakedModel getVerticalSlabModel(BlockState state, Direction side) {
-        return verticalModels.get(state).get(side);
+		final var normalisedState = state.setValue(BlockStateProperties.WATERLOGGED, false);
+		return verticalModels.get(normalisedState).get(side);
     }
 
     @Override


### PR DESCRIPTION
Fixes  #311 - **Vertical slabs crash the game when placed in water (and prevent reloading world)**

It was trying to use the block state to index into a map of maps, but wasn't unsetting `waterlogged` on the indexing block state first, so it ended up dereferencing a null pointer.
From what I can see this fixes both the initial crash and the inability to load back into the world afterwards on all three loaders.

Presumably the same fix will have to be added for the other game versions too.