### PR TITLE
(1.21.1) Vertical slab model orientation

### DIFF
--- a/common/src/main/java/cjminecraft/doubleslabs/api/helpers/IHorizontalSlabHelper.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/api/helpers/IHorizontalSlabHelper.java
@@ -31,7 +31,8 @@ public interface IHorizontalSlabHelper {
     Half getHalf(BlockGetter level, BlockPos pos, BlockState state);
 
     BlockState getStateForHalf(BlockGetter level, BlockPos pos, BlockState state, Half half);
-
+	
+	boolean isHalf(BlockState state, Half half);
     boolean isDoubleSlab(BlockState state);
 
     default boolean areSameTypeOfSlab(BlockState state, ItemStack stack) {

--- a/common/src/main/java/cjminecraft/doubleslabs/client/model/VerticalSlabModelBaker.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/client/model/VerticalSlabModelBaker.java
@@ -11,12 +11,15 @@ import net.minecraft.client.renderer.block.BlockModelShaper;
 import net.minecraft.client.renderer.block.model.BlockModel;
 import net.minecraft.client.resources.model.*;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -45,7 +48,7 @@ public class VerticalSlabModelBaker {
             final var helper = Internal.getSlabHelper().getHorizontalSlabHelper(block);
 
             if (helper.isPresent()) {
-                bakeVariants(block, helper.get());
+                bakeVariants(block);
                 count++;
             }
         }
@@ -83,27 +86,24 @@ public class VerticalSlabModelBaker {
         itemModels.put(item, bakedModel);
     }
 
-    private void bakeVariants(final Block block, final IHorizontalSlabHelper helper) {
+    private void bakeVariants(final Block block) {
 		final var directionalModels = Maps.<Direction, BakedModel>newEnumMap(Direction.class);
-        block.getStateDefinition().getPossibleStates().stream()
-                .filter(Predicates.not(helper::isDoubleSlab)
-				.and(state -> !state.hasProperty(BlockStateProperties.WATERLOGGED) || !state.getValue(BlockStateProperties.WATERLOGGED)))
-                .forEach(state -> {
-					var resourceLocation = BlockModelShaper.stateToModelLocation(state).id().withPrefix("block/");
-					if (helper.isHalf(state, Half.POSITIVE)) {
-						resourceLocation = resourceLocation.withSuffix("_top");
-						// Positive Z
-						directionalModels.put(Direction.SOUTH, modelBaker.bake(resourceLocation, BlockModelRotation.X90_Y180));
-						// Positive X
-						directionalModels.put(Direction.EAST,  modelBaker.bake(resourceLocation, BlockModelRotation.X90_Y90));
-					}
-					if (helper.isHalf(state, Half.NEGATIVE)) {
-						// Negative Z
-						directionalModels.put(Direction.NORTH, modelBaker.bake(resourceLocation, BlockModelRotation.X90_Y180));
-						// Negative X
-						directionalModels.put(Direction.WEST,  modelBaker.bake(resourceLocation, BlockModelRotation.X90_Y90));
-					}
-				});
+		var resourceLocation = BuiltInRegistries.BLOCK.getKey(block).withPrefix("block/");
+		directionalModels.put(Direction.NORTH, bakeVariant(resourceLocation, Direction.NORTH));
+		directionalModels.put(Direction.SOUTH, bakeVariant(resourceLocation, Direction.SOUTH));
+		directionalModels.put(Direction.EAST,  bakeVariant(resourceLocation, Direction.EAST));
+		directionalModels.put(Direction.WEST,  bakeVariant(resourceLocation, Direction.WEST));
 		verticalModels.put(block, directionalModels);
     }
+	
+	private @Nullable BakedModel bakeVariant(final ResourceLocation resourceLocation, final Direction direction) {
+		//final var resourceLocationVertical = resourceLocation.withSuffix("_vertical_" + direction.toString());
+		final var resourceLocationHorizontal = (direction == Direction.SOUTH || direction == Direction.EAST) ? resourceLocation.withSuffix("_top") : resourceLocation;
+		final var rotation = switch (direction) {
+			case Direction.NORTH, Direction.SOUTH -> BlockModelRotation.X90_Y180;
+			case Direction.WEST, Direction.EAST -> BlockModelRotation.X90_Y90;
+			default -> BlockModelRotation.X0_Y0;
+		};
+		return modelBaker.bake(resourceLocationHorizontal, rotation);
+	}
 }

--- a/common/src/main/java/cjminecraft/doubleslabs/client/model/VerticalSlabModelBaker.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/client/model/VerticalSlabModelBaker.java
@@ -1,6 +1,7 @@
 package cjminecraft.doubleslabs.client.model;
 
 import cjminecraft.doubleslabs.api.helpers.IHorizontalSlabHelper;
+import cjminecraft.doubleslabs.api.state.Half;
 import cjminecraft.doubleslabs.common.Constants;
 import cjminecraft.doubleslabs.common.Internal;
 import cjminecraft.doubleslabs.library.helpers.VerticalSlabModelHelper;
@@ -22,7 +23,7 @@ import java.util.function.Function;
 
 public class VerticalSlabModelBaker {
 
-    private final Map<BlockState, Map<Direction, BakedModel>> verticalModels = new HashMap<>();
+    private final Map<Block, Map<Direction, BakedModel>> verticalModels = new HashMap<>();
     private final Map<Item, BakedModel> itemModels = new HashMap<>();
 
     protected final PlatformIndependentModelBaker modelBaker;
@@ -83,23 +84,26 @@ public class VerticalSlabModelBaker {
     }
 
     private void bakeVariants(final Block block, final IHorizontalSlabHelper helper) {
+		final var directionalModels = Maps.<Direction, BakedModel>newEnumMap(Direction.class);
         block.getStateDefinition().getPossibleStates().stream()
                 .filter(Predicates.not(helper::isDoubleSlab)
-                        .and(state -> !state.hasProperty(BlockStateProperties.WATERLOGGED)
-                                || !state.getValue(BlockStateProperties.WATERLOGGED)))
-                .forEach(this::bake);
+				.and(state -> !state.hasProperty(BlockStateProperties.WATERLOGGED) || !state.getValue(BlockStateProperties.WATERLOGGED)))
+                .forEach(state -> {
+					var resourceLocation = BlockModelShaper.stateToModelLocation(state).id().withPrefix("block/");
+					if (helper.isHalf(state, Half.POSITIVE)) {
+						resourceLocation = resourceLocation.withSuffix("_top");
+						// Positive Z
+						directionalModels.put(Direction.SOUTH, modelBaker.bake(resourceLocation, BlockModelRotation.X90_Y180));
+						// Positive X
+						directionalModels.put(Direction.EAST,  modelBaker.bake(resourceLocation, BlockModelRotation.X90_Y90));
+					}
+					if (helper.isHalf(state, Half.NEGATIVE)) {
+						// Negative Z
+						directionalModels.put(Direction.NORTH, modelBaker.bake(resourceLocation, BlockModelRotation.X90_Y180));
+						// Negative X
+						directionalModels.put(Direction.WEST,  modelBaker.bake(resourceLocation, BlockModelRotation.X90_Y90));
+					}
+				});
+		verticalModels.put(block, directionalModels);
     }
-
-    private void bake(final BlockState state) {
-        final var resourceLocation = BlockModelShaper.stateToModelLocation(state).id().withPrefix("block/");
-
-        final var directionalModels = Maps.<Direction, BakedModel>newEnumMap(Direction.class);
-        directionalModels.put(Direction.NORTH, modelBaker.bake(resourceLocation, BlockModelRotation.X90_Y180));
-        directionalModels.put(Direction.EAST,  modelBaker.bake(resourceLocation, BlockModelRotation.X90_Y270));
-        directionalModels.put(Direction.SOUTH, modelBaker.bake(resourceLocation, BlockModelRotation.X90_Y0));
-        directionalModels.put(Direction.WEST,  modelBaker.bake(resourceLocation, BlockModelRotation.X90_Y90));
-
-        verticalModels.put(state, directionalModels);
-    }
-
 }

--- a/common/src/main/java/cjminecraft/doubleslabs/library/helpers/VerticalSlabModelHelper.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/library/helpers/VerticalSlabModelHelper.java
@@ -4,23 +4,24 @@ import cjminecraft.doubleslabs.api.helpers.IVerticalSlabModelHelper;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.Map;
 
 public class VerticalSlabModelHelper implements IVerticalSlabModelHelper {
 
-    private final Map<BlockState, Map<Direction, BakedModel>> verticalModels;
+    private final Map<Block, Map<Direction, BakedModel>> verticalModels;
     private final Map<Item, BakedModel> itemModels;
 
-    public VerticalSlabModelHelper(Map<BlockState, Map<Direction, BakedModel>> verticalModels, Map<Item, BakedModel> itemModels) {
+    public VerticalSlabModelHelper(Map<Block, Map<Direction, BakedModel>> verticalModels, Map<Item, BakedModel> itemModels) {
         this.verticalModels = verticalModels;
         this.itemModels = itemModels;
     }
 
     @Override
     public BakedModel getVerticalSlabModel(BlockState state, Direction side) {
-        return verticalModels.get(state).get(side);
+        return verticalModels.get(state.getBlock()).get(side);
     }
 
     @Override

--- a/common/src/main/java/cjminecraft/doubleslabs/library/plugins/vanilla/helpers/MinecraftSlabHelper.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/library/plugins/vanilla/helpers/MinecraftSlabHelper.java
@@ -36,6 +36,15 @@ public class MinecraftSlabHelper implements IHorizontalSlabHelper {
             case DOUBLE -> throw new IllegalStateException("Cannot get the half for a double slab");
         };
     }
+	
+	@Override
+	public boolean isHalf(BlockState state, Half half) {
+		return switch (state.getValue(BlockStateProperties.SLAB_TYPE)) {
+			case BOTTOM -> half == Half.NEGATIVE;
+			case TOP -> half == Half.POSITIVE;
+			default -> false;
+		};
+	}
 
     @Override
     public boolean isDoubleSlab(BlockState state) {


### PR DESCRIPTION
Previously, we were generating all the vertical slab models by rotating the bottom slab model, which made certain vertical double slabs look strange. I've switched it to using the top slab model for the positive half and the bottom slab model for the negative half.

Before:
<img width="854" height="480" alt="2025-10-04_15 53 52" src="https://github.com/user-attachments/assets/d0dbeb21-ff44-4209-ae08-5f5715edf2fd" />

After:
<img width="854" height="480" alt="2025-10-04_16 36 28" src="https://github.com/user-attachments/assets/870cb5c6-3ea9-40df-bf37-8779d0e9d39e" />

This rotation method still leaves us with weird-looking differences between how vertical slabs behave as opposed to normal slabs & stairs, so we should probably switch to attempting to load a dedicated vertical slab model and then falling back to the rotated horizontal slab model (so one could fix that with a resource pack), but I don't know how to do that so I'm leaving it here for now.
