### PR TITLE
[1.21.1] Fix vertical slab orientation

### DIFF
--- a/common/src/main/java/cjminecraft/doubleslabs/api/helpers/IHorizontalSlabHelper.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/api/helpers/IHorizontalSlabHelper.java
@@ -1,12 +1,10 @@
 package cjminecraft.doubleslabs.api.helpers;
 
 import cjminecraft.doubleslabs.api.state.Half;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
-import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -28,9 +26,9 @@ public interface IHorizontalSlabHelper {
         return isHorizontalSlab(stack.getItem());
     }
 
-    Half getHalf(BlockGetter level, BlockPos pos, BlockState state);
+    Half getHalf(BlockState state);
 
-    BlockState getStateForHalf(BlockGetter level, BlockPos pos, BlockState state, Half half);
+    BlockState getStateForHalf(BlockState state, Half half);
 
     boolean isDoubleSlab(BlockState state);
 

--- a/common/src/main/java/cjminecraft/doubleslabs/client/model/PlatformIndependentModelBaker.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/client/model/PlatformIndependentModelBaker.java
@@ -1,5 +1,7 @@
 package cjminecraft.doubleslabs.client.model;
 
+import net.minecraft.client.renderer.block.model.MultiVariant;
+import net.minecraft.client.renderer.block.model.Variant;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.*;
 import net.minecraft.resources.ResourceLocation;
@@ -19,9 +21,44 @@ public abstract class PlatformIndependentModelBaker implements ModelBaker {
         return bakery.getModel(resourceLocation);
     }
 
+    public @Nullable UnbakedModel getTopLevelModel(ModelResourceLocation modelResourceLocation) {
+        return bakery.topLevelModels.get(modelResourceLocation);
+    }
+
     @Override
     public @Nullable BakedModel bake(ResourceLocation resourceLocation, ModelState modelState) {
-        final var model = getModel(resourceLocation);
+        return bake(getModel(resourceLocation), modelState);
+    }
+
+    public @Nullable BakedModel bake(ModelResourceLocation modelResourceLocation, ModelState modelState) {
+        return bake(getTopLevelModel(modelResourceLocation), modelState);
+    }
+
+    private @Nullable BakedModel bake(@Nullable final UnbakedModel model, final ModelState modelState) {
+        if (model == null) {
+            return null;
+        }
+
+        // Baking a multi-variant model will not use the provided model state
+        if (model instanceof MultiVariant multiVariant) {
+            if (multiVariant.getVariants().isEmpty()) {
+                return null;
+            }
+
+            final var builder = new WeightedBakedModel.Builder();
+
+            for (final var variant : multiVariant.getVariants()) {
+                // Construct a new variant which is a combination of the original variant and the new variant to bake
+                final var bakedVariant = bake(variant.getModelLocation(), new Variant(
+                        variant.getModelLocation(),
+                        modelState.getRotation().compose(variant.getRotation()),
+                        modelState.isUvLocked() || variant.isUvLocked(), variant.getWeight())
+                );
+                builder.add(bakedVariant, variant.getWeight());
+            }
+
+            return builder.build();
+        }
 
         return model.bake(this, this::getTextureSprite, modelState);
     }

--- a/common/src/main/java/cjminecraft/doubleslabs/client/model/VerticalSlabModelBaker.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/client/model/VerticalSlabModelBaker.java
@@ -1,6 +1,7 @@
 package cjminecraft.doubleslabs.client.model;
 
 import cjminecraft.doubleslabs.api.helpers.IHorizontalSlabHelper;
+import cjminecraft.doubleslabs.api.state.Half;
 import cjminecraft.doubleslabs.common.Constants;
 import cjminecraft.doubleslabs.common.Internal;
 import cjminecraft.doubleslabs.library.helpers.VerticalSlabModelHelper;
@@ -87,19 +88,32 @@ public class VerticalSlabModelBaker {
                 .filter(Predicates.not(helper::isDoubleSlab)
                         .and(state -> !state.hasProperty(BlockStateProperties.WATERLOGGED)
                                 || !state.getValue(BlockStateProperties.WATERLOGGED)))
-                .forEach(this::bake);
+                .forEach(state -> bake(state, helper));
     }
 
-    private void bake(final BlockState state) {
-        final var resourceLocation = BlockModelShaper.stateToModelLocation(state).id().withPrefix("block/");
+    private void bake(final BlockState state, final IHorizontalSlabHelper helper) {
+        final var resourceLocation = BlockModelShaper.stateToModelLocation(state);
+        final var half = helper.getHalf(state);
 
         final var directionalModels = Maps.<Direction, BakedModel>newEnumMap(Direction.class);
-        directionalModels.put(Direction.NORTH, modelBaker.bake(resourceLocation, BlockModelRotation.X90_Y180));
-        directionalModels.put(Direction.EAST,  modelBaker.bake(resourceLocation, BlockModelRotation.X90_Y270));
-        directionalModels.put(Direction.SOUTH, modelBaker.bake(resourceLocation, BlockModelRotation.X90_Y0));
-        directionalModels.put(Direction.WEST,  modelBaker.bake(resourceLocation, BlockModelRotation.X90_Y90));
+
+        for (final var direction : Direction.Plane.HORIZONTAL) {
+            directionalModels.put(direction, modelBaker.bake(resourceLocation, getVerticalModelRotation(half, direction)));
+        }
 
         verticalModels.put(state, directionalModels);
+    }
+
+    private static ModelState getVerticalModelRotation(final Half half, final Direction direction) {
+        // For the positive state, we want to flip the rotations
+        return switch (half == Half.NEGATIVE ? direction : direction.getOpposite()) {
+            case NORTH -> BlockModelRotation.X90_Y180;
+            case EAST -> BlockModelRotation.X90_Y270;
+            case SOUTH -> BlockModelRotation.X90_Y0;
+            case WEST -> BlockModelRotation.X90_Y90;
+
+            default -> BlockModelRotation.X0_Y0;
+        };
     }
 
 }

--- a/common/src/main/java/cjminecraft/doubleslabs/common/hooks/DoubleSlabBlockHooks.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/common/hooks/DoubleSlabBlockHooks.java
@@ -63,8 +63,8 @@ public class DoubleSlabBlockHooks {
     }
 
     private static boolean separateDoubleSlab(final Level level, final Player player, final IHorizontalSlabHelper slabHelper, final BlockState slabBlockState, final BlockPos slabPos, final Half halfToRemove) {
-        final var stateToRemove = slabHelper.getStateForHalf(level, slabPos, slabBlockState, halfToRemove);
-        final var remainingSlabState = slabHelper.getStateForHalf(level, slabPos, slabBlockState, halfToRemove.getOpposite());
+        final var stateToRemove = slabHelper.getStateForHalf(slabBlockState, halfToRemove);
+        final var remainingSlabState = slabHelper.getStateForHalf(slabBlockState, halfToRemove.getOpposite());
 
         if (!level.setBlock(slabPos, remainingSlabState, 3)) {
             return false;

--- a/common/src/main/java/cjminecraft/doubleslabs/common/hooks/PlacementHooks.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/common/hooks/PlacementHooks.java
@@ -275,7 +275,7 @@ public class PlacementHooks {
                 // If we are clicking on the top or bottom of a double slab, try to place relative
                 // Otherwise, try to combine the slabs
                 if (!clickedBlockSlabHelper.isDoubleSlab(clickedBlockState)) {
-                    final var half = clickedBlockSlabHelper.getHalf(level, clickedPos, clickedBlockState);
+                    final var half = clickedBlockSlabHelper.getHalf(clickedBlockState);
                     // Check that the side clicked is the side that would place the slab within the same block
                     if ((half == Half.NEGATIVE && clickedFace == Direction.UP) || (half == Half.POSITIVE && clickedFace == Direction.DOWN)) {
                         return tryCombineHorizontalSlabs(level, clickedBlockState, clickedPos, player, itemInHand, hand,
@@ -326,10 +326,10 @@ public class PlacementHooks {
             return Optional.empty();
         }
 
-        final var slabBlockHalf = slabBlockHelper.getHalf(level, slabPos, slabBlockState);
+        final var slabBlockHalf = slabBlockHelper.getHalf(slabBlockState);
         final var slabToPlaceHalf = slabBlockHalf.getOpposite();
 
-        final var slabToPlaceState = slabItemHelper.getStateForHalf(level, slabPos, stateFromSlabItem, slabToPlaceHalf);
+        final var slabToPlaceState = slabItemHelper.getStateForHalf(stateFromSlabItem, slabToPlaceHalf);
 
         final var bothSlabsOcclude = slabToPlaceState.canOcclude() && slabBlockState.canOcclude();
 

--- a/common/src/main/java/cjminecraft/doubleslabs/common/item/VerticalSlabItem.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/common/item/VerticalSlabItem.java
@@ -66,7 +66,7 @@ public class VerticalSlabItem extends BlockItem {
                     originalState.getValue(VerticalSlabBlock.TYPE).getHalf().getOpposite()
                     : newType.getHalf();
 
-            final var slabState = helper.getStateForHalf(level, pos, stateFromSlabItem, half);
+            final var slabState = helper.getStateForHalf(stateFromSlabItem, half);
             dynamicSlab.setBlockState(half, slabState);
 
             if (slabState.hasBlockEntity()) {

--- a/common/src/main/java/cjminecraft/doubleslabs/library/plugins/vanilla/helpers/MinecraftSlabHelper.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/library/plugins/vanilla/helpers/MinecraftSlabHelper.java
@@ -2,10 +2,8 @@ package cjminecraft.doubleslabs.library.plugins.vanilla.helpers;
 
 import cjminecraft.doubleslabs.api.helpers.IHorizontalSlabHelper;
 import cjminecraft.doubleslabs.api.state.Half;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
-import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -29,7 +27,7 @@ public class MinecraftSlabHelper implements IHorizontalSlabHelper {
     }
 
     @Override
-    public Half getHalf(BlockGetter level, BlockPos pos, BlockState state) {
+    public Half getHalf(BlockState state) {
         return switch (state.getValue(BlockStateProperties.SLAB_TYPE)) {
             case BOTTOM -> Half.NEGATIVE;
             case TOP -> Half.POSITIVE;
@@ -43,7 +41,7 @@ public class MinecraftSlabHelper implements IHorizontalSlabHelper {
     }
 
     @Override
-    public BlockState getStateForHalf(BlockGetter level, BlockPos pos, BlockState state, Half half) {
+    public BlockState getStateForHalf(BlockState state, Half half) {
         return state.setValue(BlockStateProperties.SLAB_TYPE, half == Half.POSITIVE ? SlabType.TOP : SlabType.BOTTOM);
     }
 }

--- a/common/src/main/resources/META-INF/accesstransformer.cfg
+++ b/common/src/main/resources/META-INF/accesstransformer.cfg
@@ -2,5 +2,7 @@ public net.minecraft.world.item.context.UseOnContext getHitResult()Lnet/minecraf
 public net.minecraft.world.item.context.UseOnContext m_43718_()Lnet/minecraft/world/phys/BlockHitResult;
 public net.minecraft.client.resources.model.ModelBakery getModel(Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/resources/model/UnbakedModel;
 public net.minecraft.client.resources.model.ModelBakery m_119341_(Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/resources/model/UnbakedModel; # getModel
+public net.minecraft.client.resources.model.ModelBakery topLevelModels # topLevelModels
+public net.minecraft.client.resources.model.ModelBakery f_119214_ # topLevelModels
 public net.minecraft.client.Minecraft itemColors # itemColors
 public net.minecraft.client.Minecraft f_91041_ # itemColors

--- a/common/src/main/resources/doubleslabs.accesswidener
+++ b/common/src/main/resources/doubleslabs.accesswidener
@@ -2,5 +2,6 @@ accessWidener v2 named
 
 accessible method net/minecraft/world/item/context/UseOnContext getHitResult ()Lnet/minecraft/world/phys/BlockHitResult;
 accessible method net/minecraft/client/resources/model/ModelBakery getModel (Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/resources/model/UnbakedModel;
+accessible field net/minecraft/client/resources/model/ModelBakery topLevelModels Ljava/util/Map;
 accessible class net/minecraft/client/resources/model/ModelManager$ReloadState
 accessible field net/minecraft/client/Minecraft itemColors Lnet/minecraft/client/color/item/ItemColors;

--- a/neoforge/src/main/java/cjminecraft/doubleslabs/neoforge/client/model/NeoForgeModelBaker.java
+++ b/neoforge/src/main/java/cjminecraft/doubleslabs/neoforge/client/model/NeoForgeModelBaker.java
@@ -1,7 +1,6 @@
 package cjminecraft.doubleslabs.neoforge.client.model;
 
 import cjminecraft.doubleslabs.client.model.PlatformIndependentModelBaker;
-import net.minecraft.client.renderer.block.model.BlockModel;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.*;
 import net.minecraft.resources.ResourceLocation;
@@ -16,7 +15,7 @@ public class NeoForgeModelBaker extends PlatformIndependentModelBaker {
 
     @Override
     public @Nullable UnbakedModel getTopLevelModel(ModelResourceLocation modelResourceLocation) {
-        return null;
+        return bakery.topLevelModels.get(modelResourceLocation);
     }
 
     @Override


### PR DESCRIPTION
As raised in #320, all the vertical slab models were for the bottom slab model which resulted in strange looking double vertical slabs.

This PR fixes this by using the correct model for each variant of horizontal slab that gets rotated.

Before:
<img width="854" height="480" alt="2025-10-04_15 53 52" src="https://github.com/user-attachments/assets/d0dbeb21-ff44-4209-ae08-5f5715edf2fd" />

After:
<img width="854" height="480" alt="2025-10-04_16 36 28" src="https://github.com/user-attachments/assets/870cb5c6-3ea9-40df-bf37-8779d0e9d39e" />

_Note: this must be applied to 1.20 too._