### PR TITLE
(1.21.1) Prevent spamming the logs when getting capabilities

### DIFF
--- a/forge/src/main/java/cjminecraft/doubleslabs/forge/common/state/ForgeSlabStateContainer.java
+++ b/forge/src/main/java/cjminecraft/doubleslabs/forge/common/state/ForgeSlabStateContainer.java
@@ -2,7 +2,6 @@ package cjminecraft.doubleslabs.forge.common.state;
 
 import cjminecraft.doubleslabs.api.state.IDynamicSlabStateContainer;
 import cjminecraft.doubleslabs.library.state.SlabStateContainer;
-import com.google.common.base.Preconditions;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraftforge.common.capabilities.Capability;
@@ -19,13 +18,11 @@ public class ForgeSlabStateContainer extends SlabStateContainer implements ICapa
 
     @Override
     public @NotNull <T> LazyOptional<T> getCapability(@NotNull Capability<T> capability, @Nullable Direction direction) {
-        Preconditions.checkState(blockEntity != null, "Cannot get the capability from the block entity if the block entity does not exist");
-        return blockEntity.getCapability(capability, direction);
+        return blockEntity != null ? blockEntity.getCapability(capability, direction) : LazyOptional.empty();
     }
 
     @Override
     public @NotNull <T> LazyOptional<T> getCapability(@NotNull Capability<T> capability) {
-        Preconditions.checkState(blockEntity != null, "Cannot get the capability from the block entity if the block entity does not exist");
-        return blockEntity.getCapability(capability);
+        return blockEntity != null ?  blockEntity.getCapability(capability) : LazyOptional.empty();
     }
 }


### PR DESCRIPTION
Applies #329 to 1.21.1

---
Fixes https://github.com/CJMinecraft01/DoubleSlabs/issues/324 by changing the assumption that we have a block entity when getting a capability.