### PR TITLE
(1.21.1) Fix placing vertical slabs in water crashing the game

### DIFF
--- a/common/src/main/java/cjminecraft/doubleslabs/common/hooks/MixedDoubleSlabBlockHooks.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/common/hooks/MixedDoubleSlabBlockHooks.java
@@ -140,8 +140,8 @@ public class MixedDoubleSlabBlockHooks extends DynamicSlabBlockHooks {
                     return;
                 }
 
-                var slabState = slabContainer.getBlockState();
-				slabState = slabState.setValue(BlockStateProperties.WATERLOGGED, false);
+                var slabState = slabContainer.getBlockState()
+                        .trySetValue(BlockStateProperties.WATERLOGGED, false);
 
                 level.setBlock(pos, slabState, level.isClientSide() ? 11 : 3);
 

--- a/common/src/main/java/cjminecraft/doubleslabs/common/hooks/MixedDoubleSlabBlockHooks.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/common/hooks/MixedDoubleSlabBlockHooks.java
@@ -18,6 +18,7 @@ import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.BlockHitResult;
@@ -139,7 +140,8 @@ public class MixedDoubleSlabBlockHooks extends DynamicSlabBlockHooks {
                     return;
                 }
 
-                final var slabState = slabContainer.getBlockState();
+                var slabState = slabContainer.getBlockState();
+				slabState = slabState.setValue(BlockStateProperties.WATERLOGGED, false);
 
                 level.setBlock(pos, slabState, level.isClientSide() ? 11 : 3);
 

--- a/common/src/main/java/cjminecraft/doubleslabs/library/helpers/VerticalSlabModelHelper.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/library/helpers/VerticalSlabModelHelper.java
@@ -5,6 +5,7 @@ import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 
 import java.util.Map;
 
@@ -20,7 +21,8 @@ public class VerticalSlabModelHelper implements IVerticalSlabModelHelper {
 
     @Override
     public BakedModel getVerticalSlabModel(BlockState state, Direction side) {
-        return verticalModels.get(state).get(side);
+		final var normalisedState = state.setValue(BlockStateProperties.WATERLOGGED, false);
+		return verticalModels.get(normalisedState).get(side);
     }
 
     @Override

--- a/common/src/main/java/cjminecraft/doubleslabs/library/helpers/VerticalSlabModelHelper.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/library/helpers/VerticalSlabModelHelper.java
@@ -21,7 +21,7 @@ public class VerticalSlabModelHelper implements IVerticalSlabModelHelper {
 
     @Override
     public BakedModel getVerticalSlabModel(BlockState state, Direction side) {
-		final var normalisedState = state.setValue(BlockStateProperties.WATERLOGGED, false);
+		final var normalisedState = state.trySetValue(BlockStateProperties.WATERLOGGED, false);
 		return verticalModels.get(normalisedState).get(side);
     }
 


### PR DESCRIPTION
As raised in #311, placing a vertical slab in water will crash the game because we cannot find the model to render for the 'waterlogged' state. 
The fixes were created in #318 and #315 for 1.21.1 but I want to get these merged in as soon as possible so I've took those PRs and merged them with the changes I requested in this PR.