### PR TITLE
(1.20.1) (Fabric) Fix vertical slab breaking particle

### DIFF
--- a/fabric/src/main/java/cjminecraft/doubleslabs/fabric/mixin/client/ParticleEngineMixin.java
+++ b/fabric/src/main/java/cjminecraft/doubleslabs/fabric/mixin/client/ParticleEngineMixin.java
@@ -24,7 +24,7 @@ public class ParticleEngineMixin {
             return;
         }
 
-        if (state.is(DSBlocks.MIXED_SLABS)) {
+        if (state.is(DSBlocks.MIXED_SLABS) || state.is(DSBlocks.VERTICAL_SLAB.get())) {
             if (DynamicSlabBlockClientHooks.addDestroyEffects(level, pos, (ParticleEngine) (Object) this)) {
                 ci.cancel();
             }


### PR DESCRIPTION
Applies #333 to 1.20.1

---

Fixes https://github.com/CJMinecraft01/DoubleSlabs/issues/316 by adding the destroy effects to the vertical slab