### PR TITLE
(1.21.1) Fix #325 by checking if the item's block is not null

### DIFF
--- a/common/src/main/java/cjminecraft/doubleslabs/library/plugins/vanilla/helpers/MinecraftSlabHelper.java
+++ b/common/src/main/java/cjminecraft/doubleslabs/library/plugins/vanilla/helpers/MinecraftSlabHelper.java
@@ -23,7 +23,10 @@ public class MinecraftSlabHelper implements IHorizontalSlabHelper {
 
     @Override
     public boolean isHorizontalSlab(Item item) {
-        return item instanceof BlockItem blockItem && isHorizontalSlab(blockItem.getBlock().defaultBlockState());
+        //noinspection ConstantValue - Some mods have set their block for a block item to be null
+        return item instanceof BlockItem blockItem &&
+                blockItem.getBlock() != null &&
+                isHorizontalSlab(blockItem.getBlock().defaultBlockState());
     }
 
     @Override


### PR DESCRIPTION
Applies #330 to 1.21.1

---

Fix #325 by adding a null check around the block item `getBlock` call - whilst the types imply this is never null, the issue in question suggests that it can be set to null.