### PR TITLE
(1.20.1) (Fabric) Use the vertical slab state for culling vertical slabs

### DIFF
--- a/fabric/src/main/java/cjminecraft/doubleslabs/fabric/mixin/client/AbstractBlockRenderContextMixin.java
+++ b/fabric/src/main/java/cjminecraft/doubleslabs/fabric/mixin/client/AbstractBlockRenderContextMixin.java
@@ -1,14 +1,22 @@
 package cjminecraft.doubleslabs.fabric.mixin.client;
 
+import cjminecraft.doubleslabs.common.init.DSBlocks;
 import cjminecraft.doubleslabs.fabric.api.client.IDynamicSlabRenderContext;
 import net.fabricmc.fabric.impl.client.indigo.renderer.render.AbstractBlockRenderContext;
 import net.fabricmc.fabric.impl.client.indigo.renderer.render.BlockRenderInfo;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import javax.annotation.Nullable;
 
 @SuppressWarnings("UnstableApiUsage")
 @Mixin(AbstractBlockRenderContext.class)
@@ -16,8 +24,44 @@ public class AbstractBlockRenderContextMixin implements IDynamicSlabRenderContex
 
     @Shadow(remap = false) @Final protected BlockRenderInfo blockInfo;
 
+    private final BlockPos.MutableBlockPos searchPos = new BlockPos.MutableBlockPos();
+
+    private int cullCompletionFlags;
+    private int cullResultFlags;
+
     @Override
     public void prepareForBlock(BlockState blockState, BlockPos blockPos, BakedModel model) {
         blockInfo.prepareForBlock(blockState, blockPos, model.useAmbientOcclusion());
+
+        cullCompletionFlags = 0;
+        cullResultFlags = 0;
+    }
+
+    @Inject(remap = false, method = "isFaceCulled", at = @At("HEAD"), cancellable = true)
+    private void isFaceCulled$doubleslabs(@Nullable Direction face, CallbackInfoReturnable<Boolean> cir) {
+        if (face == null) {
+            return;
+        }
+
+        if (blockInfo.blockView != null && blockInfo.blockPos != null) {
+            final var actualState = blockInfo.blockView.getBlockState(blockInfo.blockPos);
+
+            if (!actualState.is(DSBlocks.VERTICAL_SLAB.get())) {
+                return;
+            }
+
+            // Use the actual vertical slab state for culling
+            final var mask = 1 << face.get3DDataValue();
+
+            if ((cullCompletionFlags & mask) == 0) {
+                cullCompletionFlags |= mask;
+
+                if (Block.shouldRenderFace(actualState, blockInfo.blockView, blockInfo.blockPos, face, searchPos.setWithOffset(blockInfo.blockPos, face))) {
+                    cullResultFlags |= mask;
+                }
+            }
+
+            cir.setReturnValue((cullResultFlags & mask) == 0);
+        }
     }
 }


### PR DESCRIPTION
Applies #337 to 1.20.1

---

Fixes #319 by using the vertical slab state when culling vertical slabs.

Before
<img width="854" height="480" alt="image" src="https://github.com/user-attachments/assets/3bfeeaf8-613d-45f5-87ab-735360062461" />

After
<img width="1920" height="1057" alt="2026-01-10_13 32 12" src="https://github.com/user-attachments/assets/18e65a3f-0412-4c91-86f7-595fa7a2303a" />
