### PR TITLE
fix: culling issue with vertical slabs when using Sodium

### DIFF
--- a/fabric/src/main/java/cjminecraft/doubleslabs/fabric/client/model/VerticalSlabBakedModel.java
+++ b/fabric/src/main/java/cjminecraft/doubleslabs/fabric/client/model/VerticalSlabBakedModel.java
@@ -40,7 +40,7 @@ public class VerticalSlabBakedModel extends FabricDynamicSlabBakedModel {
                         blockRenderDispatcher.getBlockModel(slabState) :
                         ClientInternal.getVerticalSlabModelHelper().getVerticalSlabModel(slabState, direction);
 
-                ((IDynamicSlabRenderContext) context).prepareForBlock(slabState, pos, model.useAmbientOcclusion());
+                ((IDynamicSlabRenderContext) context).prepareForBlock(state, pos, model.useAmbientOcclusion());
 
                 model.emitBlockQuads(blockView, state, pos, randomSupplier, context);
             });


### PR DESCRIPTION
This fix is related to the Issue #344, please refer to it for more informations about the bug itself.

The bug was only related to a variable name in `prepareForBlock` method: `slabState -> state`.

I tested this fix by myself in my client.

~ @M4elstr0m

